### PR TITLE
Add button to discover stranded threads

### DIFF
--- a/mboard/static/js/js.js
+++ b/mboard/static/js/js.js
@@ -57,7 +57,7 @@ if ($('.threadList,.threadPage')) { // at least one class ("OR")
     $$('.video-thumb').forEach((video) => video.addEventListener('click', expandVideo));
     $('.js-fetch-new-posts')?.addEventListener('click', fetchNewPosts);
 
-    discoverBtn.addEventListener('click', discoverNewThreads)
+document.getElementById('discoverBtn').addEventListener('click', discoverNewThreads)
     $$('.quote, .reply').forEach((elmnt) => elmnt.addEventListener('click', onClick));
     document.addEventListener('mouseover', function (ev) {
         if (ev.target.classList.contains('quote') || ev.target.classList.contains('reply')) {
@@ -370,7 +370,6 @@ function constructReplyElmnt(quote) {
 
 
 function discoverNewThreads() {
-    const lastLoadedPost = $$('article')[$$('article').length - 1];
     let pathname = window.location.pathname;
     pathname = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
     const urlparams = pathname +'/discover_new_threads.json';
@@ -379,11 +378,9 @@ function discoverNewThreads() {
         method: "GET",
         headers: {
             "X-Requested-With": "XMLHttpRequest",
-            "If-Modified-Since": getLastPostDate(lastLoadedPost),
         },
     })
         .then(response => {
-            const fetchStatus = document.getElementById('fetchStatus');
             if (response.status === 200) {
                 response.json().then(data => {
                 console.log(data);

--- a/mboard/static/js/js.js
+++ b/mboard/static/js/js.js
@@ -56,6 +56,8 @@ if ($('.threadList,.threadPage')) { // at least one class ("OR")
     $$('.image').forEach((image) => image.addEventListener('click', expandImage));
     $$('.video-thumb').forEach((video) => video.addEventListener('click', expandVideo));
     $('.js-fetch-new-posts')?.addEventListener('click', fetchNewPosts);
+
+    discoverBtn.addEventListener('click', discoverNewThreads)
     $$('.quote, .reply').forEach((elmnt) => elmnt.addEventListener('click', onClick));
     document.addEventListener('mouseover', function (ev) {
         if (ev.target.classList.contains('quote') || ev.target.classList.contains('reply')) {
@@ -366,6 +368,44 @@ function constructReplyElmnt(quote) {
     }
 }
 
+
+function discoverNewThreads() {
+    const lastLoadedPost = $$('article')[$$('article').length - 1];
+    let pathname = window.location.pathname;
+    pathname = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+    const urlparams = pathname +'/discover_new_threads.json';
+
+    fetch('' + urlparams, {
+        method: "GET",
+        headers: {
+            "X-Requested-With": "XMLHttpRequest",
+            "If-Modified-Since": getLastPostDate(lastLoadedPost),
+        },
+    })
+        .then(response => {
+            const fetchStatus = document.getElementById('fetchStatus');
+            if (response.status === 200) {
+                response.json().then(data => {
+                console.log(data);
+                discoverBox.innerHTML = data; });
+            }
+            if (response.status === 304) {
+                fetchStatus.hidden = false;
+                setTimeout(function () {
+                    fetchStatus.hidden = true;
+                }, 10000); // 10 sec
+            }
+        });
+
+}
+
+function getLastPostDate(lastLoadedPost) {
+    const timestamp = lastLoadedPost.querySelector('.date').dataset.unixtime;
+    const lastPostDate = new Date(timestamp * 1000);  //milliseconds to seconds
+    lastPostDate.setSeconds(lastPostDate.getSeconds() + 1);
+    return lastPostDate.toUTCString();
+}
+
 function fetchNewPosts() {
     const lastLoadedPost = $$('article')[$$('article').length - 1];
     let pathname = window.location.pathname;
@@ -376,7 +416,7 @@ function fetchNewPosts() {
         method: "GET",
         headers: {
             "X-Requested-With": "XMLHttpRequest",
-            "If-Modified-Since": getLastPostDate(),
+            "If-Modified-Since": getLastPostDate(lastLoadedPost),
         },
     })
         .then(response => {
@@ -392,12 +432,6 @@ function fetchNewPosts() {
             }
         });
 
-    function getLastPostDate() {
-        const timestamp = lastLoadedPost.querySelector('.date').dataset.unixtime;
-        const lastPostDate = new Date(timestamp * 1000);  //milliseconds to seconds
-        lastPostDate.setSeconds(lastPostDate.getSeconds() + 1);
-        return lastPostDate.toUTCString();
-    }
 }
 
 function insert(newPosts) {

--- a/mboard/urls.py
+++ b/mboard/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls.static import static
 from django.urls import path
 from django.shortcuts import redirect
 from mboard.views import list_threads, get_thread, ajax_tooltips_onhover, ajax_load_new_posts, \
-    captcha_ajax_validation, ajax_posting, info_page, post_vote
+    captcha_ajax_validation, ajax_posting, info_page, post_vote, ajax_discover_new_threads
 
 app_name = 'mboard'
 
@@ -14,6 +14,7 @@ urlpatterns = [
     path('posting/', ajax_posting),
     path('', lambda request: redirect('mboard:list_threads', board='b')),
     path('<str:board>/', list_threads, name='list_threads'),
+    path('<str:board>/discover_new_threads.json', ajax_discover_new_threads),
     path('<str:board>/<int:pagenum>/', list_threads, name='threads_paginator'),
     path('<str:board>/thread/<int:thread_id>/', get_thread, name='get_thread'),
     path('<str:board>/thread/<int:thread_id>/<int:post_id>.json', ajax_tooltips_onhover),

--- a/mboard/views.py
+++ b/mboard/views.py
@@ -1,3 +1,4 @@
+import random
 from email.utils import parsedate_to_datetime
 from random import randint
 from django.conf import settings
@@ -178,7 +179,10 @@ def ajax_tooltips_onhover(request, thread_id, **kwargs):
         thread = Post.objects.get(pk=thread_id)
         post_ids = {thread.pk: thread.posts_ids()}
         jsn = render_to_string('post.html',
-                               {'post': post, 'thread': thread, 'posts_ids': post_ids}, request)
+                               {'post': post,
+                                'thread': thread,
+                                'posts_ids': post_ids},
+                               request)
         return JsonResponse(jsn, safe=False)
 
 
@@ -186,6 +190,20 @@ def ajax_tooltips_onhover(request, thread_id, **kwargs):
 def ajax_load_new_posts(request, thread_id, **kwargs):  # don't proceed if no new posts, return 304 response
     thread = Post.objects.get(pk=thread_id)
     return get_new_posts(request, thread)
+
+
+def ajax_discover_new_threads(request, board, **kwargs):  # don't proceed if no new posts, return 304 response
+    board = get_object_or_404(Board, board_link=board)
+    user = refresh_rank(request)
+    stranded_threads = multi_annotate(user, board.post_set.all().filter(thread__isnull=True)).filter(rank=0.0)
+    thread = random.choice(stranded_threads)
+    post_ids = {thread.pk: thread.posts_ids()}
+    jsn = render_to_string('OPpost.html',
+                           {'post': thread,
+                            'thread': thread,
+                            'posts_ids': post_ids},
+                           request)
+    return JsonResponse(jsn, safe=False)
 
 
 def get_new_posts(request, thread):

--- a/mboard/views.py
+++ b/mboard/views.py
@@ -73,7 +73,7 @@ def multi_annotate(user, threads):
                 user=user,
                 target=OuterRef('session')
             ).values('vote'))
-    ).order_by('-rank')
+    )
 
 
 def create_new_thread(request, board, ):
@@ -97,7 +97,7 @@ def list_threads(request, board, pagenum=1):
     user = refresh_rank(request)
 
     threads = board.post_set.all().filter(thread__isnull=True)
-    threads = multi_annotate(user, threads)
+    threads = multi_annotate(user, threads).exclude(rank=0.0).order_by('-rank')
 
     threads_dict, posts_ids = {}, {}
     paginator = Paginator(threads, 10)

--- a/templates/list_threads.html
+++ b/templates/list_threads.html
@@ -5,6 +5,10 @@
     {% translate 'New thread' as btn %}
     {% include 'postform.html' with postformbutton=btn %}
     <hr>
+    <button class="btn btn-primary" id="discoverBtn">Discover</button>
+    <hr>
+    <div id="discoverBox"></div>
+    <hr>
     {% for thread, posts in threads.items %}
       <section class="thread" data-threadid="{{ thread.pk }}">
         {% include 'OPpost.html' %}


### PR DESCRIPTION
To protect from whitewashing, we'll have to implement a zero-tolerance stranger policy meaning that we never show disconnected threads in the main listing. Therefore, we get to the bootstrap problem #14. 
This PR fixes #14 by adding a button to show a random thread with 0.0 rank (e.g. new, "stranded" threads) to the user. 

![изображение](https://user-images.githubusercontent.com/2509103/197406280-4cd27c3c-e4a9-4f99-b432-a6dfe96a8bac.png)
