### PR TITLE
Hide troll posts

### DIFF
--- a/projectconfig/settings.py
+++ b/projectconfig/settings.py
@@ -15,7 +15,7 @@ APPEND_SLASH = True
 
 SESSION_COOKIE_AGE = 60 * 60 * 24 * 365 * 10  # ~ 10 years
 
-RECALCULATE = False
+RANK_DEBUG = False
 
 CAPTCHA_FONT_SIZE = 27
 CAPTCHA_LETTER_ROTATION = None
@@ -29,7 +29,7 @@ else:
 
 BBCODE_DISABLE_BUILTIN_TAGS = True
 BBCODE_ALLOW_SMILIES = False
-BBCODE_ESCAPE_HTML = []  # disable bbcode's esacaping
+BBCODE_ESCAPE_HTML = []  # disable bbcode's escaping
 BBCODE_ALLOW_CUSTOM_TAGS = True
 INSTALLED_APPS = [
     'django.contrib.admin',

--- a/templates/OPpost.html
+++ b/templates/OPpost.html
@@ -9,7 +9,9 @@
     </span>
     <div id="voting" style="display: inline-block">
       {% if request.session.session_key != thread.session.session_key %}
-        <span id="rank" style="color: green">Rank: {{ thread.rank }}</span>
+        {% if thread.vote != 0.0 or rank_debug %}
+          <span id="rank" style="color: green">Rank: {{ thread.rank|floatformat:3}}</span>
+        {% endif %}
         <button id="downvote" type="button" onclick="vote(this, 0)">-</button>
         <button id="upvote" type="button" onclick="vote(this, 1)">+</button>
         <span id="vote" style="color: red">{{ thread.vote }}</span>

--- a/templates/post.html
+++ b/templates/post.html
@@ -6,7 +6,9 @@
     <a class="postLink" href="{{ thread.get_absolute_url }}#id{{ post.pk }}">№:{{ post.pk }}</a>
     <div id="voting" style="display: inline-block">
       {% if request.session.session_key != post.session.session_key %}
-        <span id="rank" style="color: green">Rank: {{ post.rank|default_if_none:0.0 }}</span>
+        {% if post.vote != 0.0 or rank_debug %}
+          <span id="rank" style="color: green">Rank: {{ post.rank|floatformat:3 }}</span>
+        {% endif %}
         <button id="downvote" type="button" onclick="vote(this, 0)">-</button>
         <button id="upvote" type="button" onclick="vote(this, 1)">+</button>
         <span id="vote" style="color: red">{{ post.vote }}</span>

--- a/testconf.py
+++ b/testconf.py
@@ -1,2 +1,2 @@
 from projectconfig.settings import *
-RECALCULATE = True
+RANK_DEBUG = True


### PR DESCRIPTION
This PR adds several important features:
* posts with a rank less than a threshold are hidden from the user (effective personalized shadowban)
* negative votes get 10x more power than positive ones
* to prevent "priming" users with their peer's opinions, post rankings are hidden until the user personally votes for the post (this effect is disabled in the `testconf` mode to make the debugging easier)
